### PR TITLE
few facelift and botox injections for libnmap

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+v0.4.5, 06/04/2014 -- minor fixes and botox injections
+                    - Added "incomplete" argument in NmapReport.parse()
+                      in order to enable parsing of incomplete or interrupted
+                      nmap scans. Could be useful to use with a background
+                      scan to parse incomplete data blocks from callback
+                      function (thanks @Sibwara for the idea).
+                    - Fixed bug when NmapReport.summary is empty
+                    - added NmapReport.endtimestr
+                    - remplaced ElementTree by cElementTree (performance)
 v0.4.4, 04/04/2014 -- Bugs and features requests
                     - added support for tunnel attribute from <service> tag
                     - added support for servicefp (service fingerprint) in

--- a/TODO
+++ b/TODO
@@ -1,12 +1,10 @@
 - review OS fingerprint API and add NmapOSFP class
 - add unit test for os fingerprint class
-- complete unit tests
+- complete unit tests with coverall support
 - review and improve threading for NmapProcess
-- XML interface to support both ElementTree and lxml APIs
 - support for python3
-- support for windows and cywin
+- support for windows
 - Add new plugins to support import/export from mysql, couchdb, csv
-- support iterators for NmapReport::hosts
 - add unittest for udp scans, ping sweeping
 - add support for 'resume' capability (see nmap --resume)
 - add support for "not shown ports" (extra ports) in NmapHost (via NmapParser)

--- a/libnmap/objects/report.py
+++ b/libnmap/objects/report.py
@@ -154,6 +154,21 @@ class NmapReport(object):
         return rval
 
     @property
+    def endtimestr(self):
+        """
+            Accessor returning a human readable time string
+            of when the scan ended.
+
+            :return: string
+        """
+        rval = ''
+        try:
+            rval = self._runstats['finished']['timestr']
+        except(KeyError, TypeError, ValueError):
+            pass
+        return rval
+
+    @property
     def summary(self):
         """
             Accessor returning a string describing and
@@ -167,6 +182,12 @@ class NmapReport(object):
         except(KeyError, TypeError):
             pass
 
+        if len(rval) == 0:
+            rval = ("Nmap ended at {0} ; {1} IP addresses ({2} hosts up)"
+                    " scanned in {3} seconds".format(self.endtimestr,
+                                                     self.hosts_total,
+                                                     self.hosts_up,
+                                                     self.elapsed))
         return rval
 
     @property


### PR DESCRIPTION
v0.4.5, 06/04/2014 -- minor fixes and botox injections
                    - Added "incomplete" argument in NmapReport.parse()
                       in order to enable parsing of incomplete or interrupted
                       nmap scans. Could be useful to use with a background
                       scan to parse incomplete data blocks from callback
                       function (thanks @Sibwara for the idea).
                    - Fixed bug when NmapReport.summary is empty
                    - added NmapReport.endtimestr
                    - remplaced ElementTree by cElementTree (performance)
