### PR TITLE
Add a sleep in NmapProcess.__wait to reduce CPU overhead

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -7,6 +7,7 @@ import threading
 from threading import Thread
 from xml.dom import pulldom
 import warnings
+import time
 try:
     from Queue import Queue, Empty, Full
 except ImportError:
@@ -271,6 +272,7 @@ class NmapProcess(Thread):
                     self.__nmap_event_callback(self)
                 self.__stdout += thread_stream
                 self.__io_queue.task_done()
+            time.sleep(0.01)
 
         self.__nmap_rc = self.__nmap_proc.poll()
         if self.rc is None:


### PR DESCRIPTION
Add a short delay between checks for process termination or output.   This has the down side of reducing the resolution of our polling for output from, or completion of the command, but has the benefit of greatly reducing CPU utilization in libnmap.  Before this change we would sit at 100% CPU in libnmap while a long running scan was in progress.  I noticed this when my laptop fan wound up while running a slow scan.

It seemed like there should be a better way to do this so I am open to suggestions.

Some metrics, please note `user` and `sys` times.

Before change:

```
$ time python libnmap/process.py --help
Progress: 0% - ETC: 0
Progress: 23.08% - ETC: 1396900582
Progress: 23.08% - ETC: 1396900582
Progress: 84.62% - ETC: 1396900569
Progress: 84.62% - ETC: 1396900569
Progress: 84.62% - ETC: 1396900569
Scan started at 1396900556 nmap version: 6.40
state: 0 (rc: 0)
results size: 9103
Scan ended 1396900567: Nmap done at Mon Apr  7 12:56:07 2014; 1 IP address (1 host up) scanned in 11.20 seconds

real    0m11.251s
user    0m10.841s
sys 0m0.604s
```

After change:

```
$ time python libnmap/process.py --help
Progress: 0% - ETC: 0
Progress: 23.08% - ETC: 1396900600
Progress: 23.08% - ETC: 1396900600
Progress: 84.62% - ETC: 1396900587
Progress: 84.62% - ETC: 1396900587
Progress: 84.62% - ETC: 1396900587
Scan started at 1396900573 nmap version: 6.40
state: 0 (rc: 0)
results size: 9103
Scan ended 1396900585: Nmap done at Mon Apr  7 12:56:25 2014; 1 IP address (1 host up) scanned in 11.22 seconds

real    0m11.579s
user    0m0.340s
sys 0m0.052s
```
