### PR TITLE
Export `NmapProcess` only.

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -13,6 +13,10 @@ try:
 except ImportError:
     from queue import Queue, Empty, Full
 
+__all__ = [
+    'NmapProcess'
+]
+
 
 class NmapProcess(Thread):
     """


### PR DESCRIPTION
This patch will only add the class `NmapProcess` to `globals()` when `from libnmap import *` is used.
