### PR TITLE
Call the callback one last time.

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -331,7 +331,7 @@ class NmapProcess(Thread):
                 self.__nmap_tasks[self.current_task.name].progress = 100
         else:
             self.__state = self.FAILED
-        #Call the callback one last time to signal the new state
+        # Call the callback one last time to signal the new state
         if self.__nmap_event_callback:
             self.__nmap_event_callback(self)
         return self.rc

--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -331,6 +331,9 @@ class NmapProcess(Thread):
                 self.__nmap_tasks[self.current_task.name].progress = 100
         else:
             self.__state = self.FAILED
+        #Call the callback one last time to signal the new state
+        if self.__nmap_event_callback:
+            self.__nmap_event_callback(self)
         return self.rc
 
     def run_background(self):

--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -358,8 +358,8 @@ class NmapProcess(Thread):
 
         :return: True if nmap process is not running anymore.
         """
-        return (self.state == self.DONE or self.state == self.FAILED
-                or self.state == self.CANCELLED)
+        return (self.state == self.DONE or self.state == self.FAILED or
+                self.state == self.CANCELLED)
 
     def has_failed(self):
         """


### PR DESCRIPTION
The status is updated way after the event handler is called, also any output remaining on the queue will be processed without calling the callback. This prevents such
conditions which amongst other things allows to have callbacks like this:

def mycallback(nm):
    if (nm.has_terminated()):
        print ("Done!")