### PR TITLE
Fix a bytes-to-str conversion in python 3.4

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -260,7 +260,7 @@ class NmapProcess(Thread):
 
         while self.__nmap_proc.poll() is None:
             for streamline in iter(self.__nmap_proc.stdout.readline, ''):
-                self.__stdout += streamline
+                self.__stdout += str(streamline)
                 evnt = self.__process_event(streamline)
                 if self.__nmap_event_callback and evnt:
                     self.__nmap_event_callback(self)


### PR DESCRIPTION
I was testing this in python 3.4 and ran into a bytes-to-str conversion error. Adding a str() fixed this.

I ran some of the examples and it seemed to run fine after the fix. I wasn't sure how to run all the test code so I'll leave that to you.