### PR TITLE
Python 3.4 stream readline uses bytes instead of string

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -259,8 +259,8 @@ class NmapProcess(Thread):
                                       "not be found in system path")
 
         while self.__nmap_proc.poll() is None:
-            for streamline in iter(self.__nmap_proc.stdout.readline, ''):
-                self.__stdout += str(streamline)
+            for streamline in iter(self.__nmap_proc.stdout.readline, b''):
+                self.__stdout += streamline.decode('utf-8')
                 evnt = self.__process_event(streamline)
                 if self.__nmap_event_callback and evnt:
                     self.__nmap_event_callback(self)


### PR DESCRIPTION
In my previous pull request, I only fix the obvious crash. However, there was more. I'm not 100% sure of the problem and the solution, but the current code works for me.

In python 3.4, the readline used for streams seems to return an empty byte array instead of an empty string. Without this, it keeps looping for streams.

My fix simply replaces '' with bytes(), however I'm not convinced this works for python versions other than 3.4. We'll have the build bot check it out first. If this doesn't work for the other versions, I'm not sure I can fix it, I might need some help.

My theory is that this was never caught because all the test cases run from files instead of from an actual nmap process.

My context and use case was https://groups.google.com/forum/#!msg/home-assistant-dev/hKcH32MzQvs/kF98gmFCIUQJ and I'm hoping for a new libnmap release soon :)
