### PR TITLE
Fix parsing of nmap script output with multiple elements or tables

### DIFF
--- a/libnmap/parser.py
+++ b/libnmap/parser.py
@@ -473,8 +473,22 @@ class NmapParser(object):
             elif script_elem.tag == 'table':
                 tdict = {}
                 for telem in script_elem:
-                    tdict[telem.get('key')] = telem.text
-                _elt_dict[script_elem.get('key')] = tdict
+                    #Handle duplicate element keys
+                    tkey = telem.get('key')
+                    if tkey in tdict:
+                        if not isinstance(tdict[tkey], list):
+                            tdict[tkey] = [tdict[tkey],]
+                        tdict[tkey].append(telem.text)
+                    else:
+                        tdict[tkey] = telem.text
+                #Handle duplicate table keys
+                skey = script_elem.get('key')
+                if skey in _elt_dict:
+                    if not isinstance(_elt_dict[skey], list):
+                        _elt_dict[skey] = [_elt_dict[skey],]
+                    _elt_dict[skey].append(tdict)
+                else:
+                    _elt_dict[skey] = tdict
         _script_dict['elements'] = _elt_dict
         return _script_dict
 

--- a/libnmap/parser.py
+++ b/libnmap/parser.py
@@ -473,19 +473,19 @@ class NmapParser(object):
             elif script_elem.tag == 'table':
                 tdict = {}
                 for telem in script_elem:
-                    #Handle duplicate element keys
+                    # Handle duplicate element keys
                     tkey = telem.get('key')
                     if tkey in tdict:
                         if not isinstance(tdict[tkey], list):
-                            tdict[tkey] = [tdict[tkey],]
+                            tdict[tkey] = [tdict[tkey], ]
                         tdict[tkey].append(telem.text)
                     else:
                         tdict[tkey] = telem.text
-                #Handle duplicate table keys
+                # Handle duplicate table keys
                 skey = script_elem.get('key')
                 if skey in _elt_dict:
                     if not isinstance(_elt_dict[skey], list):
-                        _elt_dict[skey] = [_elt_dict[skey],]
+                        _elt_dict[skey] = [_elt_dict[skey], ]
                     _elt_dict[skey].append(tdict)
                 else:
                     _elt_dict[skey] = tdict


### PR DESCRIPTION
libnmap parser fails to parse nse scripts output correctly if there are multiple table or elem elements without key. For example, the output of ssh-hostkey and ssh2-enum-algos which takes the form
```xml
<table>
<elem key='a'>a1</elem>
<elem key='b'>b1</elem>
</table>
<table>
<elem key='c'>c1</elem>
<elem key='d'>c2</elem>
</table>
```
and
```xml
<table key='blah'>
<elem>1</elem>
<elem>2</elem>
</table>
```
respectively.

Admittedly, the scripts in question could produce a better formatted xml. Also, the xml to dict conversion could be standardized across all xml elements rather than just fixing it for scripts.
