### PR TITLE
Fix import error that does not allow running library in Windows OS

### DIFF
--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import os
-import pwd
 import shlex
 import subprocess
 from threading import Thread
 from xml.dom import pulldom
 import warnings
+try:
+    import pwd
+except ImportError:
+    pass
 
 
 __all__ = [


### PR DESCRIPTION
The pwd module cannot be imported in Windows (10) OS.
This module is only used in sudo* methods so it should not affect
the library functionality when running in Windows