### PR TITLE
More supported Python versions (3.5 and 3.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 env:
 #  - MONGO_VERSION=1.2.12
@@ -36,6 +38,6 @@ deploy:
   on:
     tags: true
   provider: pypi
-  user: savon_noir 
+  user: savon_noir
   password:
     secure: WiMQsq+IMzAsS+cNKyKT7u7PlwGwkH0t2eoBitP0ckIw6kNWlbM/HCCm6aa9Ns9LpIzI82x26Vg77bu+yiMxUzZPS8pxCJXL9fFGs7Qc6VC9S0iHUX+FCkhFEFvPl35YRGFuY0YQyF2oj9vZPPFFmXzY2JSOBHxVevgdsrw1BQM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ before_install:
   - "sudo apt-get update -qq"
   - "sudo apt-get install nmap -qq"
 install:
-  - "pip install pep8 --use-mirrors"
-  - "pip install pyflakes --use-mirrors"
-#  - "pip install boto --use-mirrors" # disabled: since boto not supporting py3
-#  - "pip install pymongo sqlalchemy MySQL-python --use-mirrors" # disabled MySQL-python (not py3 compatible)
-  - "pip install pymongo sqlalchemy pymysql --use-mirrors"
+  - "pip install pep8"
+  - "pip install pyflakes"
+#  - "pip install boto" # disabled: since boto not supporting py3
+#  - "pip install pymongo sqlalchemy MySQL-python" # disabled MySQL-python (not py3 compatible)
+  - "pip install pymongo sqlalchemy pymysql"
   - "pip install coveralls"
   - "python setup.py install"
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -66,13 +66,15 @@ The libnmap code is tested against the following python interpreters:
 - Python 2.7
 - Python 3.3
 - Python 3.4
+- Python 3.5
+- Python 3.6
 
 Install
 -------
 
 You can install libnmap via pip::
 
-    pip install python-libnmap 
+    pip install python-libnmap
 
 or via git::
 

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,7 @@ setup(
                  "Programming Language :: Python :: 3",
                  "Programming Language :: Python :: 3.3",
                  "Programming Language :: Python :: 3.4",
+                 "Programming Language :: Python :: 3.5",
+                 "Programming Language :: Python :: 3.6",
                  "Topic :: System :: Networking"]
 )


### PR DESCRIPTION
The documentation states that the code is compatible with Python version 2.6 to 3.4, this pull request expands that to version 3.5 and 3.6 by adding those version to the Travis build and reflecting this change in the documentation (Github summary should also be modified).

An additional change was also required: The pip option `--use-mirrors` options is removed from pip since version 7.0.0 (2015-05-21), which results in a build failure on Travis. Because PyPI is using a CDN now, an alternative to the `--use-mirrors` is not needed so I removed the option from the Travis script.