### PR TITLE
Adding xmlversion, startedstr, and numservices

### DIFF
--- a/libnmap/objects/report.py
+++ b/libnmap/objects/report.py
@@ -83,6 +83,21 @@ class NmapReport(object):
             pass
         return rval
 
+	@property
+	def startedstr(self):
+		"""
+			Accessor returning a human readable string of when the 
+			scan was started
+
+			:return: string
+		"""
+		rval = ''
+		try:
+			rval = self.['_nmaprun']['startstr']
+		except(KeyError, TypeError, ValueError):
+			pass
+		return rval
+			
     @property
     def commandline(self):
         """
@@ -102,6 +117,16 @@ class NmapReport(object):
         """
         return self._nmaprun['version']
 
+	@property
+	def xmlversion(self):
+		"""
+			Accessor returning the XML output
+			version of the nmap report.
+		
+			:return: string
+		"""
+		return self._nmaprun['xmloutputversion']
+
     @property
     def scan_type(self):
         """
@@ -111,6 +136,22 @@ class NmapReport(object):
             :return: string
         """
         return self._scaninfo.get('type')
+
+	@property
+	def numservices(self):
+		"""
+			Accessor returning the number of services the 
+			scan attempted to enumerate.
+
+			:return: integer
+		"""
+		rval = -1
+		try:
+			s_numsvcs = self._scaninfo.get('numservices')
+			rval = int(s_numsvcs)
+		except(KeyError, TypeError, ValueError):
+			pass
+		return rval
 
     @property
     def hosts(self):


### PR DESCRIPTION
Why *NOT* expose these as properties?  They are useful in various nmap data manipulation tasks.