### PR TITLE
Update .travis.yml for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: python
 python:
-#  - "2.5" Not needed EL can use epel to upgrade to 2.6
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 env:
-#  - MONGO_VERSION=1.2.12
-#  - MONGO_VERSION=1.3.2
-#  - MONGO_VERSION=1.3.7
   - MONGO_VERSION=2.4.3
 
 services: mongodb


### PR DESCRIPTION
- Python 2.6 and 3.3 not really used anymore + tests are failing
- Add Python 3.7 test run
- Remove some commented out things that don't seem to be needed