### PR TITLE
Set encoding for README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from distutils.core import setup
 
-with open("README.rst") as rfile:
+with open("README.rst", encoding="utf-8") as rfile:
     long_description = rfile.read()
 
 setup(


### PR DESCRIPTION
As the default encoding is platform dependent, python-libnmap can not be installed if the preferred encoding is not UTF-8.