### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/diff.rst
+++ b/docs/diff.rst
@@ -17,7 +17,7 @@ Those methods return a python set() of keys which have been changed/added/remove
 object to another.
 The keys of each objects could be found in the implementation of the get_dict() methods of the compared objects.
 
-The example below is a heavy version of going through all nested objects to see waht has changed after a diff::
+The example below is a heavy version of going through all nested objects to see what has changed after a diff::
 
     #!/usr/bin/env python
     

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ libnmap is a python toolkit for manipulating nmap. It currently offers the follo
 - plugins: enables you to support datastores for your scan results directly in the "NmapReport" object from report module
 
   - mongodb: only plugin implemented so far, ultra basic, for POC purpose only
-  - sqlalchemy: Allow to store/retreive NmapReport to sqlite/mysql/... all engine supported by sqlalchemy
+  - sqlalchemy: Allow to store/retrieve NmapReport to sqlite/mysql/... all engine supported by sqlalchemy
   - rabbitMQ : todo
   - couchdb: todo
   - elastic search: todo

--- a/docs/parser.rst
+++ b/docs/parser.rst
@@ -63,7 +63,7 @@ Using libnmap.parser module
 
 NmapParser parse the whole data and returns nmap objects usable via their documented API.
 
-The NmapParser should never be instanciated and only the following methods should be called:
+The NmapParser should never be instantiated and only the following methods should be called:
 
 - NmapParser.parse(string)
 - NmapParser.parse_fromfile(file_path)

--- a/libnmap/objects/os.py
+++ b/libnmap/objects/os.py
@@ -269,7 +269,7 @@ class NmapOSClass(object):
 class NmapOSFingerprint(object):
     """
     NmapOSFingerprint is a easier API for using os fingerprinting.
-    Data for OS fingerprint (<os> tag) is instanciated from
+    Data for OS fingerprint (<os> tag) is instantiated from
     a NmapOSFingerprint which is accessible in NmapHost via NmapHost.os
     """
 

--- a/libnmap/objects/report.py
+++ b/libnmap/objects/report.py
@@ -254,7 +254,7 @@ class NmapReport(object):
     @property
     def hosts_up(self):
         """
-        Accessor returning the numer of host detected
+        Accessor returning the number of host detected
         as 'up' during the scan.
 
         :return: integer (0 >= or -1)
@@ -270,7 +270,7 @@ class NmapReport(object):
     @property
     def hosts_down(self):
         """
-        Accessor returning the numer of host detected
+        Accessor returning the number of host detected
         as 'down' during the scan.
 
         :return: integer (0 >= or -1)

--- a/libnmap/plugins/backendplugin.py
+++ b/libnmap/plugins/backendplugin.py
@@ -30,7 +30,7 @@ class NmapBackendPlugin(object):
 
     def get(self, id):
         """
-        retreive a NmapReport from the backend
+        retrieve a NmapReport from the backend
         :param id: str
         :return: NmapReport
         """

--- a/libnmap/plugins/es.py
+++ b/libnmap/plugins/es.py
@@ -48,7 +48,7 @@ class NmapElasticsearchPlugin(NmapBackendPlugin):
 
     def get(self, id):
         """
-        retreive a NmapReport from the backend
+        retrieve a NmapReport from the backend
         :param id: str
         :return: NmapReport
         """

--- a/libnmap/plugins/mongodb.py
+++ b/libnmap/plugins/mongodb.py
@@ -15,7 +15,7 @@ class NmapMongodbPlugin(NmapBackendPlugin):
     Implementation is made using pymongo
     Object of this class must be create via the
     BackendPluginFactory.create(**url) where url is a named dict like
-    {'plugin_name': "mongodb"} this dict may reeive all the param
+    {'plugin_name': "mongodb"} this dict may receive all the param
     MongoClient() support
     """
 

--- a/libnmap/plugins/sql.py
+++ b/libnmap/plugins/sql.py
@@ -77,7 +77,7 @@ class NmapSqlPlugin(NmapBackendPlugin):
         - create all the necessary obj to discuss with the DB
         - create all the mapping(ORM)
 
-        todo : suport the : sqlalchemy.engine_from_config
+        todo : support the : sqlalchemy.engine_from_config
 
         :param **kwargs:
         :raises: ValueError if no url is given,
@@ -121,7 +121,7 @@ class NmapSqlPlugin(NmapBackendPlugin):
 
     def get(self, report_id=None):
         """
-        retreive a NmapReport from the backend
+        retrieve a NmapReport from the backend
 
         :param id: str
 

--- a/libnmap/process.py
+++ b/libnmap/process.py
@@ -22,7 +22,7 @@ class NmapTask(object):
 
     """
     NmapTask is a internal class used by process. Each time nmap
-    starts a new task during the scan, a new class will be instanciated.
+    starts a new task during the scan, a new class will be instantiated.
     Classes examples are: "Ping Scan", "NSE script", "DNS Resolve",..
     To each class an estimated time to complete is assigned and updated
     at least every second within the NmapProcess.
@@ -215,7 +215,7 @@ class NmapProcess(Thread):
     def sudo_run(self, run_as="root"):
         """
         Public method enabling the library's user to run the scan with
-        priviledges via sudo. The sudo configuration should be set manually
+        privileges via sudo. The sudo configuration should be set manually
         on the local system otherwise sudo will prompt for a password.
         This method alters the command line by prefixing the sudo command to
         nmap and will then call self.run()
@@ -245,7 +245,7 @@ class NmapProcess(Thread):
     def sudo_run_background(self, run_as="root"):
         """
         Public method enabling the library's user to run in background a
-        nmap scan with priviledges via sudo.
+        nmap scan with privileges via sudo.
         The sudo configuration should be set manually on the local system
         otherwise sudo will prompt for a password.
         This method alters the command line by prefixing the sudo command to


### PR DESCRIPTION
There are small typos in:
- docs/diff.rst
- docs/index.rst
- docs/parser.rst
- libnmap/objects/os.py
- libnmap/objects/report.py
- libnmap/plugins/backendplugin.py
- libnmap/plugins/es.py
- libnmap/plugins/mongodb.py
- libnmap/plugins/sql.py
- libnmap/process.py

Fixes:
- Should read `retrieve` rather than `retreive`.
- Should read `instantiated` rather than `instanciated`.
- Should read `privileges` rather than `priviledges`.
- Should read `number` rather than `numer`.
- Should read `what` rather than `waht`.
- Should read `support` rather than `suport`.
- Should read `receive` rather than `reeive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md