### PR TITLE
Fix Windows charmap exception for quote characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,10 @@ The lib currently offers the following modules:
    de/serialize scan results in a json format
 -  **diff**: enables you to see what changed between two scans
 -  **common**: contains basic nmap objects like NmapHost and
-   NmapService. It is to note that each object can be “diff()ed” with
+   NmapService. It is to note that each object can be "diff()ed" with
    another similar object.
 -  **plugins**: enables you to support datastores for your scan results
-   directly in the “NmapReport” object. from report module:
+   directly in the "NmapReport" object. from report module:
 
    -  mongodb: insert/get/getAll/delete
    -  sqlalchemy: insert/get/getAll/delete


### PR DESCRIPTION
When installing on Windows with `pip install python-libnmap`, these characters cause the error:
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\xxxxx\AppData\Local\Temp\pip-install-207o7yaz\python-libnmap_bed69037734a4da9af455445b772adb2\setup.py", line 5, in <module>
        long_description = rfile.read()
      File "C:\Python38\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1117: character maps to <undefined>
```

This should fix https://github.com/savon-noir/python-libnmap/issues/123, which is still occurring on 0.7.2.