### PR TITLE
fix: replace deprecated distutils with setuptools

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pre-commit
 pytest
 pytest-cov
 flake8
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+from setuptools import setup
 
 with open("README.rst", encoding="utf-8") as rfile:
     long_description = rfile.read()


### PR DESCRIPTION
Update setup.py from 'distutils' to 'setuptools' due to 'distutils' being deprecated in Python 3.12

Details: https://peps.python.org/pep-0632/